### PR TITLE
Add base simplesaml module to composer require.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require": {
         "php": ">=5.4.0",
+        "simplesamlphp/simplesamlphp": "*",
         "simplesamlphp/composer-module-installer": "~1.0",
         "predis/predis": "~1.0"
     },


### PR DESCRIPTION
Ensure that the base simpleSAMLphp module has been installed before attempting to install the redis module on a clean (first install) composer run.
